### PR TITLE
Test plugin installation against PR

### DIFF
--- a/.github/workflows/test-plugin-installation.yml
+++ b/.github/workflows/test-plugin-installation.yml
@@ -1,0 +1,20 @@
+name: Test installation of plugin against the PR
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test-plugin-installation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli
+      - name: Install plugins
+        run: |
+          set -euo pipefail
+          kurtosis run github.com/kurtosis-tech/autogpt-package '{"OPENAI_API_KEY": "test", "ALLOWLISTED_PLUGINS": "AutoGPT_IFTTT", "__plugin_branch_to_use": '\"${{ github.head_ref}}\"', "__plugin_repo_to_use":'\"${{ github.event.pull_request.head.repo.full_name }}\"'}'


### PR DESCRIPTION
This GitHub workflow launches an AutoGPT container and tests the installation of the AutoGPT-IFTT plugin. This is done using the open-source [Kurtosis AutoGPT package](https://github.com/kurtosis-tech/autogpt-package). This package is used by the AutoGPT Plugins CI to [test](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/blob/master/.github/workflows/test-plugin-installation.yml) the plugins installation.